### PR TITLE
[Feature/#47] 글쓰기 페이지 다른 페이지로 이동 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query-devtools": "^5.59.15",
         "axios": "^1.7.7",
         "husky": "^9.1.6",
+        "js-cookie": "^3.0.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.1",
@@ -23,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@types/js-cookie": "^3.0.6",
         "@types/react": "^18.3.10",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^8.11.0",
@@ -1467,6 +1469,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4140,6 +4149,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query-devtools": "^5.59.15",
     "axios": "^1.7.7",
     "husky": "^9.1.6",
+    "js-cookie": "^3.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.1",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@types/js-cookie": "^3.0.6",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.11.0",

--- a/src/features/writing/WritingPage.tsx
+++ b/src/features/writing/WritingPage.tsx
@@ -11,8 +11,9 @@ import {
 import useWritingModeStore from '../../stores/writingModeStore';
 import useChangeMode from './hooks/useChangeMode';
 import useWritingResponseStore from '../../stores/writingResponseStore';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Modal from './components/Modal';
+import useScrollFollow from './hooks/useScrollFollow';
 
 const WritingPage = () => {
   const {
@@ -26,6 +27,18 @@ const WritingPage = () => {
   useChangeMode();
   const { AiContent } = useWritingResponseStore((state) => state);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  useScrollFollow({
+    contentRef,
+    dependencies: [
+      isQuestionMode,
+      isUserResponseMode,
+      isAIResponseMode,
+      isEndMode,
+    ],
+  });
+
   const openModal = () => {
     setIsModalOpen(true);
   };
@@ -34,11 +47,11 @@ const WritingPage = () => {
   };
 
   return (
-    <WritingWrapper>
+    <WritingWrapper ref={contentRef}>
       <WritingLayout>
         {isQuestionMode && (
           <FadeIn>
-            <QuestionBox comment="요즘 어떤 고민이 있나요?" />
+            <QuestionBox comment="오늘 어떤 고민이 있나요?" />
           </FadeIn>
         )}
         {isUserResponseMode && (

--- a/src/features/writing/WritingPage.tsx
+++ b/src/features/writing/WritingPage.tsx
@@ -6,6 +6,7 @@ import {
   MoveToMainButton,
   QuestionBox,
   ResponseBox,
+  RetryButton,
 } from './components';
 import useWritingModeStore from '../../stores/writingModeStore';
 import useChangeMode from './hooks/useChangeMode';
@@ -19,6 +20,7 @@ const WritingPage = () => {
     isInputMode,
     isUserResponseMode,
     isAIResponseMode,
+    isErrorMode,
     isEndMode,
   } = useWritingModeStore((state) => state);
   useChangeMode();
@@ -62,7 +64,11 @@ const WritingPage = () => {
         {isEndMode && (
           <FadeIn>
             <ButtonContainer>
-              <ContentPublicButton onClick={openModal} />
+              {isErrorMode ? (
+                <RetryButton />
+              ) : (
+                <ContentPublicButton onClick={openModal} />
+              )}
               <MoveToMainButton />
             </ButtonContainer>
           </FadeIn>

--- a/src/features/writing/components/EntireInput.tsx
+++ b/src/features/writing/components/EntireInput.tsx
@@ -34,6 +34,7 @@ const EntireInput = () => {
         setAiContent('고민 등록에 실패했습니다 😢');
         setContentId(0);
         setIsLoadingMode(false);
+        setIsErrorMode(true);
       }, 2500);
     },
   });
@@ -46,6 +47,7 @@ const EntireInput = () => {
     setIsUserResponseMode,
     setIsLoadingMode,
     setIsAIResponseMode,
+    setIsErrorMode,
   } = useWritingModeStore((state) => state.actions);
 
   const handleSubmitContent: SubmitHandler<FormTypes> = (data) => {
@@ -71,7 +73,6 @@ const EntireInput = () => {
         emotion_type: data.emotion,
         content: data.content,
       });
-      console.log(userId);
     }
 
     Promise.resolve()

--- a/src/features/writing/components/EntireInput.tsx
+++ b/src/features/writing/components/EntireInput.tsx
@@ -7,14 +7,18 @@ import useWritingResponseStore from '../../../stores/writingResponseStore';
 import useWritingModeStore from '../../../stores/writingModeStore';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { useUser } from '../../home/hooks/useUser';
 
 interface WriteData {
-  user_id: number;
+  user_id: string;
   emotion_type: string;
   content: string;
 }
 
 const EntireInput = () => {
+  const { getUserId } = useUser();
+  const userId = getUserId().user_id;
+
   const mutation = useMutation({
     mutationFn: async (newContent: WriteData) => {
       const response = await axios.post('/api/post/write', newContent);
@@ -34,6 +38,7 @@ const EntireInput = () => {
     },
   });
   const { register, handleSubmit, reset, setFocus } = useForm<FormTypes>();
+
   const { setEmotion, setContent, setAiContent, setContentId } =
     useWritingResponseStore((state) => state.actions);
   const {
@@ -62,10 +67,11 @@ const EntireInput = () => {
         setIsAIResponseMode(true);
       }, 2000);
       mutation.mutate({
-        user_id: 5,
+        user_id: userId,
         emotion_type: data.emotion,
         content: data.content,
       });
+      console.log(userId);
     }
 
     Promise.resolve()

--- a/src/features/writing/components/Modal.tsx
+++ b/src/features/writing/components/Modal.tsx
@@ -5,6 +5,7 @@ import useWritingResponseStore from '../../../stores/writingResponseStore';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { useUser } from '../../home/hooks/useUser';
 
 interface ModalPropTypes {
   onClose: () => void;
@@ -14,10 +15,13 @@ interface ModalPropTypes {
 }
 
 interface VisibilityData {
-  user_id: number;
+  user_id: string;
 }
 
 export default function Modal(props: ModalPropTypes) {
+  const { getUserId } = useUser();
+  const userId = getUserId().user_id;
+
   const { contentId } = useWritingResponseStore((state) => state);
   const navigate = useNavigate();
 
@@ -35,7 +39,7 @@ export default function Modal(props: ModalPropTypes) {
 
   const handleConfirm = () => {
     mutation.mutate({
-      user_id: 5,
+      user_id: userId,
     });
     navigate(`/detail/community/${contentId}`);
   };

--- a/src/features/writing/components/Modal.tsx
+++ b/src/features/writing/components/Modal.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 import { Icon } from '../../../components/ui/Icon';
 import Button from './Button';
 import useWritingResponseStore from '../../../stores/writingResponseStore';
-import { useEffect } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 interface ModalPropTypes {
   onClose: () => void;
@@ -19,9 +19,7 @@ interface VisibilityData {
 
 export default function Modal(props: ModalPropTypes) {
   const { contentId } = useWritingResponseStore((state) => state);
-  useEffect(() => {
-    console.log(contentId);
-  }, [contentId]);
+  const navigate = useNavigate();
 
   const mutation = useMutation({
     mutationFn: async (userId: VisibilityData) => {
@@ -39,6 +37,7 @@ export default function Modal(props: ModalPropTypes) {
     mutation.mutate({
       user_id: 5,
     });
+    navigate('/growth');
   };
 
   return (

--- a/src/features/writing/components/Modal.tsx
+++ b/src/features/writing/components/Modal.tsx
@@ -30,10 +30,11 @@ export default function Modal(props: ModalPropTypes) {
       await axios.patch(`/api/diary/post/${contentId}/visibility`, userId);
     },
     onSuccess: () => {
-      console.log('success');
+      navigate(`/detail/community/${contentId}`);
+      window.scrollTo(0, 0);
     },
     onError: () => {
-      console.log('fail');
+      alert('공개 설정에 실패했습니다! 😢');
     },
   });
 
@@ -41,7 +42,6 @@ export default function Modal(props: ModalPropTypes) {
     mutation.mutate({
       user_id: userId,
     });
-    navigate(`/detail/community/${contentId}`);
   };
 
   return (

--- a/src/features/writing/components/Modal.tsx
+++ b/src/features/writing/components/Modal.tsx
@@ -37,7 +37,7 @@ export default function Modal(props: ModalPropTypes) {
     mutation.mutate({
       user_id: 5,
     });
-    navigate('/growth');
+    navigate(`/detail/community/${contentId}`);
   };
 
   return (

--- a/src/features/writing/components/MoveToMainButton.tsx
+++ b/src/features/writing/components/MoveToMainButton.tsx
@@ -1,7 +1,9 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const MoveToMainButton = () => {
-  return <Button>메인으로 돌아가기</Button>;
+  const navigate = useNavigate();
+  return <Button onClick={() => navigate('/growth')}>메인으로 돌아가기</Button>;
 };
 
 export default MoveToMainButton;

--- a/src/features/writing/components/MoveToMainButton.tsx
+++ b/src/features/writing/components/MoveToMainButton.tsx
@@ -1,18 +1,22 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const MoveToMainButton = () => {
-  const navigate = useNavigate();
-  return <Button onClick={() => navigate('/growth')}>메인으로 돌아가기</Button>;
+  return <Button to="/growth">메인으로 돌아가기</Button>;
 };
 
 export default MoveToMainButton;
 
-const Button = styled.button`
+const Button = styled(Link)`
   background: ${({ theme }) => theme.colors.write_white100};
   color: ${({ theme }) => theme.colors.write_purple100};
   border-radius: 14px;
   border: none;
   padding: 1rem;
   width: 100%;
+
+  text-decoration: none;
+  display: block;
+  text-align: center;
+  cursor: pointer;
 `;

--- a/src/features/writing/components/RetryButton.tsx
+++ b/src/features/writing/components/RetryButton.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const RetryButton = () => {
+  return <Button onClick={() => location.reload()}>고민 다시 등록하기</Button>;
+};
+
+export default RetryButton;
+
+const Button = styled.button`
+  background: ${({ theme }) => theme.colors.write_purple100};
+  color: ${({ theme }) => theme.colors.write_white200};
+  border-radius: 14px;
+  border: none;
+  padding: 1rem;
+  width: 100%;
+  margin: 1.5rem 0 0.5rem 0;
+`;

--- a/src/features/writing/components/index.ts
+++ b/src/features/writing/components/index.ts
@@ -4,3 +4,4 @@ export { default as ContentPublicButton } from './ContentPublicButton';
 export { default as MoveToMainButton } from './MoveToMainButton';
 export { default as LoadingSpinner } from './LoadingSpinner';
 export { default as EntireInput } from './EntireInput';
+export { default as RetryButton } from './RetryButton';

--- a/src/features/writing/hooks/useChangeMode.ts
+++ b/src/features/writing/hooks/useChangeMode.ts
@@ -3,7 +3,7 @@ import useWritingModeStore from '../../../stores/writingModeStore';
 import useWritingResponseStore from '../../../stores/writingResponseStore';
 
 const useChangeMode = () => {
-  const { isQuestionMode } = useWritingModeStore((state) => state);
+  const { isQuestionMode, isEndMode } = useWritingModeStore((state) => state);
   const { AiContent } = useWritingResponseStore((state) => state);
   const {
     setIsQuestionMode,
@@ -19,12 +19,12 @@ const useChangeMode = () => {
   }, [setIsQuestionMode]);
 
   useEffect(() => {
-    if (!isQuestionMode) return;
+    if (!isQuestionMode || isEndMode) return;
 
     setTimeout(() => {
       setIsInputMode(true);
     }, 1500);
-  }, [isQuestionMode, setIsUserResponseMode, setIsInputMode]);
+  }, [isQuestionMode, isEndMode, setIsUserResponseMode, setIsInputMode]);
 
   useEffect(() => {
     if (!AiContent) return;
@@ -33,6 +33,12 @@ const useChangeMode = () => {
       setIsEndMode(true);
     }, 1000);
   }, [AiContent, setIsEndMode]);
+
+  useEffect(() => {
+    if (isQuestionMode && isEndMode) {
+      setIsInputMode(false);
+    }
+  }, [isQuestionMode, isEndMode, setIsInputMode]);
 };
 
 export default useChangeMode;

--- a/src/features/writing/hooks/useScrollFollow.ts
+++ b/src/features/writing/hooks/useScrollFollow.ts
@@ -1,0 +1,24 @@
+import { RefObject, useEffect } from 'react';
+
+interface useScrollFollowPropTypes {
+  contentRef: RefObject<HTMLDivElement>;
+  dependencies: boolean[];
+}
+
+const useScrollFollow = ({
+  contentRef,
+  dependencies,
+}: useScrollFollowPropTypes) => {
+  useEffect(() => {
+    if (contentRef.current) {
+      const isContentOverflow =
+        contentRef.current.scrollHeight > window.innerHeight;
+
+      if (isContentOverflow) {
+        contentRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      }
+    }
+  }, [dependencies, contentRef]);
+};
+
+export default useScrollFollow;

--- a/src/stores/writingModeStore.ts
+++ b/src/stores/writingModeStore.ts
@@ -6,6 +6,7 @@ interface State {
   isUserResponseMode: boolean;
   isLoadingMode: boolean;
   isAIResponseMode: boolean;
+  isErrorMode: boolean;
   isEndMode: boolean;
 }
 
@@ -16,6 +17,7 @@ interface Actions {
     setIsUserResponseMode: (mode: boolean) => void;
     setIsLoadingMode: (mode: boolean) => void;
     setIsAIResponseMode: (mode: boolean) => void;
+    setIsErrorMode: (mode: boolean) => void;
     setIsEndMode: (mode: boolean) => void;
   };
 }
@@ -26,6 +28,7 @@ const useWritingModeStore = create<State & Actions>((set) => ({
   isUserResponseMode: false,
   isLoadingMode: false,
   isAIResponseMode: false,
+  isErrorMode: false,
   isEndMode: false,
   actions: {
     setIsQuestionMode: (mode) => set(() => ({ isQuestionMode: mode })),
@@ -33,6 +36,7 @@ const useWritingModeStore = create<State & Actions>((set) => ({
     setIsUserResponseMode: (mode) => set(() => ({ isUserResponseMode: mode })),
     setIsLoadingMode: (mode) => set(() => ({ isLoadingMode: mode })),
     setIsAIResponseMode: (mode) => set(() => ({ isAIResponseMode: mode })),
+    setIsErrorMode: (mode) => set(() => ({ isErrorMode: mode })),
     setIsEndMode: (mode) => set(() => ({ isEndMode: mode })),
   },
 }));


### PR DESCRIPTION
## 📌 과제 설명
글쓰기 페이지에서 다른 페이지로 이동하며, 이동과 관련된 API를 연결한다.

## 👩‍💻 요구 사항과 구현 내용
- [x] 내 고민 공유하기 확인 버튼을 누르면, 커뮤니티의 해당 고민 컨텐츠 페이지로 이동
- [x] 메인으로 가기 버튼을 누르면, growth 페이지로 이동
- [x] 로그인 > 글쓰기 페이지로 이동해, user_id 정보 Cookie와 연동
- [x] 글쓰기 > 메인 > 글쓰기로 돌아가면 writing 다시 뜨는 문제 해결
- [x] 정보 전송에 에러가 뜨면 고민 공개가 아닌 고민 재등록 버튼 뜨도록 변경
- [x] 내용이 100vh를 넘을 경우, 스크롤이 해당 화면을 따라 이동
- [x] 다른 페이지로 이동할 경우, 스크롤 최상단으로 이동 

## ✅ PR 포인트 & 궁금한 점
- userId를 이런 방식으로 사용하면 될까요?! @ruehan 
  - DB와 연동될 때에만 userId를 찾아서 넣어줬어요!
- 이외에 잘못된 부분이 있다면 말씀해주세요!!

- Close #47 
